### PR TITLE
add Scale statement and GUT scripts for it

### DIFF
--- a/Test/TestVNKExtensions/TestAt2D.gd
+++ b/Test/TestVNKExtensions/TestAt2D.gd
@@ -7,7 +7,7 @@ var nodes: Array[Node]
 var at_predefs := RKSShow.at_predefs
 
 func wait_test_show(xnodes: Array[Node]):
-	await wait_for_custom_statement("show", 0.2)
+	await wait_for_custom_statement(RKSShow.Show, 0.2)
 	for node: Node in xnodes:
 		assert_true(node.visible)
 
@@ -38,21 +38,21 @@ func make_test(constructor : Callable):
 	await wait_step()
 
 	var vp_size := get_viewport().get_visible_rect().size
-	await wait_for_custom_statement("at percent", 0.2)
+	await wait_for_custom_statement(RKSShow.AtPrecise, 0.2)
 	assert_eq(
 		parent.position, Vector2.ONE * 0.5 * vp_size,
 		"\n-- 'at% 50 50' %d --" % line_num
 	)
 	await wait_step()
 
-	await wait_for_custom_statement("at precise", 0.2)
+	await wait_for_custom_statement(RKSShow.AtPrecise, 0.2)
 	assert_eq(
-		parent.position, Vector2(148, 156),
+		parent.position, Vector2(148, -156),
 		"\n-- 'at 148 156' at %d --" % line_num
 	)
 	await wait_step()
 
-	await wait_for_custom_statement("at one", 0.2)
+	await wait_for_custom_statement(RKSShow.AtAxis, 0.2)
 	assert_eq(
 		parent.position.y, 200.0,
 		"\n-- 'at y 200' at %d --" % line_num
@@ -60,7 +60,7 @@ func make_test(constructor : Callable):
 	await wait_step()
 
 	var prev_x = parent.position.x
-	await wait_for_custom_statement("at one", 0.2)
+	await wait_for_custom_statement(RKSShow.AtAxis, 0.2)
 	assert_eq(
 		parent.position.x, prev_x + 50.0,
 		"\n-- 'at x + 50' at %d --" % line_num
@@ -69,7 +69,7 @@ func make_test(constructor : Callable):
 	await wait_step()
 
 	prev_x = parent.position.x
-	await wait_for_custom_statement("at one", 0.2)
+	await wait_for_custom_statement(RKSShow.AtAxis, 0.2)
 	assert_eq(
 		parent.position.x, prev_x - 25.0,
 		"\n-- 'at x -25' at %d --" % line_num
@@ -77,7 +77,7 @@ func make_test(constructor : Callable):
 	await wait_step()
 
 	prev_x = parent.position.x
-	await wait_for_custom_statement("at one", 0.2)
+	await wait_for_custom_statement(RKSShow.AtAxis, 0.2)
 	assert_eq(
 		parent.position.x, prev_x / 2.0,
 		"\n-- 'at x /2' at %d --" % line_num
@@ -85,7 +85,7 @@ func make_test(constructor : Callable):
 	await wait_step()
 
 	prev_x = parent.position.x
-	await wait_for_custom_statement("at one", 0.2)
+	await wait_for_custom_statement(RKSShow.AtAxis, 0.2)
 	assert_eq(
 		parent.position.x, prev_x * 3.0,
 		"\n-- 'at x *3' at %d --" % line_num
@@ -96,7 +96,7 @@ func make_test(constructor : Callable):
 	assert_true(childA.visible)
 	await wait_step()
 
-	await wait_for_custom_statement("at percent", 0.2)
+	await wait_for_custom_statement(RKSShow.AtPercent, 0.2)
 	assert_not_same(
 		childA.position, Vector2.ONE * 0.25 * vp_size,
 		"\n-- 'at% 25 25' at %d --" % line_num
@@ -107,77 +107,77 @@ func make_test(constructor : Callable):
 	)
 	await wait_step()
 
-	await wait_for_custom_statement("at precise", 0.2)
+	await wait_for_custom_statement(RKSShow.AtPrecise, 0.2)
 	assert_eq(
 		parent.position, Vector2.ZERO,
 		"\n-- 'at 0 0' at %d --" % line_num
 	)
 	await wait_step()
 	
-	await wait_for_custom_statement("at predef", 0.2)
+	await wait_for_custom_statement(RKSShow.AtPredef, 0.2)
 	assert_eq(
 		parent.position, at_predefs["center"] * vp_size,
 		"\n-- 'at center' at %d --" % line_num
 	)
 	await wait_step()
 
-	await wait_for_custom_statement("at predef", 0.2)
+	await wait_for_custom_statement(RKSShow.AtPredef, 0.2)
 	assert_eq(
 		parent.position, at_predefs["left"] * vp_size,
 		"\n-- 'at left' at %d --" % line_num
 	)
 	await wait_step()
 
-	await wait_for_custom_statement("at predef", 0.2)
+	await wait_for_custom_statement(RKSShow.AtPredef, 0.2)
 	assert_eq(
 		parent.position, at_predefs["right"] * vp_size,
 		"\n-- 'at right' at %d --" % line_num
 	)
 	await wait_step()
 
-	await wait_for_custom_statement("at predef", 0.2)
+	await wait_for_custom_statement(RKSShow.AtPredef, 0.2)
 	assert_eq(
 		parent.position, at_predefs["top"] * vp_size,
 		"\n-- 'at top' at %d --" % line_num
 	)
 	await wait_step()
 
-	await wait_for_custom_statement("at predef", 0.2)
+	await wait_for_custom_statement(RKSShow.AtPredef, 0.2)
 	assert_eq(
 		parent.position, at_predefs["top_left"] * vp_size,
 		"\n-- 'at top_left' at %d --" % line_num
 	)
 	await wait_step()
 
-	await wait_for_custom_statement("at predef", 0.2)
+	await wait_for_custom_statement(RKSShow.AtPredef, 0.2)
 	assert_eq(
 		parent.position, at_predefs["top_right"] * vp_size,
 		"\n-- 'at top_right' at %d --" % line_num
 	)
 	await wait_step()
 
-	await wait_for_custom_statement("at predef", 0.2)
+	await wait_for_custom_statement(RKSShow.AtPredef, 0.2)
 	assert_eq(
 		parent.position, at_predefs["bottom"] * vp_size,
 		"\n-- 'at bottom' at %d --" % line_num
 	)
 	await wait_step()
 
-	await wait_for_custom_statement("at predef", 0.2)
+	await wait_for_custom_statement(RKSShow.AtPredef, 0.2)
 	assert_eq(
 		parent.position, at_predefs["bottom_left"] * vp_size,
 		"\n-- 'at bottom_left' at %d --" % line_num
 	)
 	await wait_step()
 
-	await wait_for_custom_statement("at predef", 0.2)
+	await wait_for_custom_statement(RKSShow.AtPredef, 0.2)
 	assert_eq(
 		parent.position, at_predefs["bottom_right"] * vp_size,
 		"\n-- 'at bottom_right' at %d --" % line_num
 	)
 	await wait_step()
 
-	await wait_for_custom_statement("hide", 0.2)
+	await wait_for_custom_statement(RKSShow.Hide, 0.2)
 	assert_false(parent.visible)
 	await wait_step("end")
 

--- a/Test/TestVNKExtensions/TestAt2D.rk
+++ b/Test/TestVNKExtensions/TestAt2D.rk
@@ -3,7 +3,7 @@
 	"step"
 	at% 50 50
 	"step"
-	at 148 156
+	at 148 -156
 	"step"
 	at y 200
 	"step"

--- a/Test/TestVNKExtensions/TestAt3D.gd
+++ b/Test/TestVNKExtensions/TestAt3D.gd
@@ -7,7 +7,7 @@ var nodes: Array[Node]
 var at_predefs := RKSShow.at_predefs
 
 func wait_test_show(xnodes: Array[Node]):
-	await wait_for_custom_statement("show", 0.2)
+	await wait_for_custom_statement(RKSShow.Show, 0.2)
 	for node: Node in xnodes:
 		assert_true(node.visible)
 
@@ -34,14 +34,14 @@ func make_test(constructor : Callable):
 	await wait_test_show([parent, childA])
 	await wait_step()
 
-	await wait_for_custom_statement("at precise", 0.2)
+	await wait_for_custom_statement(RKSShow.AtPrecise, 0.2)
 	assert_eq(
-		parent.position, Vector3(148, 156, 265),
-		"\n-- 'at 148 156 265' at %d --" % line_num
+		parent.position, Vector3(148, -156, 265),
+		"\n-- 'at 148 -156 265' at %d --" % line_num
 	)
 	await wait_step()
 
-	await wait_for_custom_statement("at one", 0.2)
+	await wait_for_custom_statement(RKSShow.AtAxis, 0.2)
 	assert_eq(
 		parent.position.y, 200.0,
 		"\n-- 'at y 200' at %d --" % line_num
@@ -49,7 +49,7 @@ func make_test(constructor : Callable):
 	await wait_step()
 
 	var prev_x = parent.position.x
-	await wait_for_custom_statement("at one", 0.2)
+	await wait_for_custom_statement(RKSShow.AtAxis, 0.2)
 	assert_eq(
 		parent.position.x, prev_x + 50.0,
 		"\n-- 'at x + 50' at %d --" % line_num
@@ -58,7 +58,7 @@ func make_test(constructor : Callable):
 	await wait_step()
 
 	var prev_z = parent.position.z
-	await wait_for_custom_statement("at one", 0.2)
+	await wait_for_custom_statement(RKSShow.AtAxis, 0.2)
 	assert_eq(
 		parent.position.z, prev_z - 25.0,
 		"\n-- 'at z -25' at %d --" % line_num
@@ -66,7 +66,7 @@ func make_test(constructor : Callable):
 	await wait_step()
 
 	prev_x = parent.position.x
-	await wait_for_custom_statement("at one", 0.2)
+	await wait_for_custom_statement(RKSShow.AtAxis, 0.2)
 	assert_eq(
 		parent.position.x, prev_x / 2.0,
 		"\n-- 'at x /2' at %d --" % line_num
@@ -74,7 +74,7 @@ func make_test(constructor : Callable):
 	await wait_step()
 
 	prev_x = parent.position.x
-	await wait_for_custom_statement("at one", 0.2)
+	await wait_for_custom_statement(RKSShow.AtAxis, 0.2)
 	assert_eq(
 		parent.position.x, prev_x * 3.0,
 		"\n-- 'at x *3' at %d --" % line_num

--- a/Test/TestVNKExtensions/TestAt3D.rk
+++ b/Test/TestVNKExtensions/TestAt3D.rk
@@ -1,7 +1,7 @@
 	"start"
 	show Parent ChildA
 	"step"
-	at 148 156 265
+	at 148 -156 265
 	"step"
 	at y 200
 	"step"

--- a/Test/TestVNKExtensions/TestScale2D.gd
+++ b/Test/TestVNKExtensions/TestScale2D.gd
@@ -39,23 +39,23 @@ func make_test(constructor : Callable):
 
 	await wait_for_custom_statement(RKSShow.ScalePrecise, 0.2)
 	assert_eq(
-		parent.scale, Vector2(0.2, 0.4),
-		"\n-- 'scale 0.2 0.4' at %d --" % line_num
+		parent.scale, Vector2(0.2, -0.4),
+		"\n-- 'scale 0.2 -0.4' at %d --" % line_num
 	)
 	await wait_step()
 
 	await wait_for_custom_statement(RKSShow.ScaleAxis, 0.2)
 	assert_eq(
 		parent.scale, Vector2.ONE * 2,
-		"\n-- 'scale = 2' at %d --" % line_num
+		"\n-- 'scale xy = 2' at %d --" % line_num
 	)
 	await wait_step()
 
 	var prev_scale = parent.scale
 	await wait_for_custom_statement(RKSShow.ScaleAxis, 0.2)
 	assert_eq(
-		parent.scale, prev_scale - 2 * Vector2.ONE,
-		"\n-- 'scale -= 2' at %d --" % line_num
+		parent.scale.x, -2,
+		"\n-- 'scale x =- 2' at %d --" % line_num
 	)
 	await wait_step()
 
@@ -63,7 +63,7 @@ func make_test(constructor : Callable):
 	await wait_for_custom_statement(RKSShow.ScaleAxis, 0.2)
 	assert_almost_eq(
 		parent.scale.x, prev_x + 0.5, 0.01,
-		"\n-- 'scale x +0.5' at %d --" % line_num
+		"\n-- 'scale x += 0.5' at %d --" % line_num
 	)
 	await wait_step()
 
@@ -71,7 +71,7 @@ func make_test(constructor : Callable):
 	await wait_for_custom_statement(RKSShow.ScaleAxis, 0.2)
 	assert_almost_eq(
 		parent.scale.y, prev_y - 2.5, 0.01,
-		"\n-- 'scale y -2.5' at %d --" % line_num
+		"\n-- 'scale y -= 2.5' at %d --" % line_num
 	)
 	await wait_step()
 
@@ -79,15 +79,15 @@ func make_test(constructor : Callable):
 	await wait_for_custom_statement(RKSShow.ScaleAxis, 0.2)
 	assert_almost_eq(
 		parent.scale.x, prev_x / 2.0, 0.01,
-		"\n-- 'scale x /2' at %d --" % line_num
+		"\n-- 'scale x /= 2' at %d --" % line_num
 	)
 	await wait_step()
 
 	prev_x = parent.scale.x
 	await wait_for_custom_statement(RKSShow.ScaleAxis, 0.2)
 	assert_almost_eq(
-		parent.scale.x, prev_x * 3.0, 0.01,
-		"\n-- 'scale x *3' at %d --" % line_num
+		parent.scale.x, prev_x * 3.0, 0.1,
+		"\n-- 'scale x *= 3' at %d --" % line_num
 	)
 	await wait_step()
 

--- a/Test/TestVNKExtensions/TestScale2D.gd
+++ b/Test/TestVNKExtensions/TestScale2D.gd
@@ -1,0 +1,103 @@
+extends KitTest
+
+const file_path = "res://Test/TestVNKExtensions/TestScale2D.rk"
+var file_base_name = get_file_base_name(file_path)
+var nodes: Array[Node]
+
+var at_predefs := RKSShow.at_predefs
+
+func wait_test_show(xnodes: Array[Node]):
+	await wait_for_custom_statement("show", 0.2)
+	for node: Node in xnodes:
+		assert_true(node.visible)
+
+func test_node2d():
+	await make_test(Node2D.new)
+
+func test_control():
+	await make_test(Control.new)
+
+func make_test(constructor : Callable):
+	var parent := add_node(constructor.call(), null, "Parent")
+	parent.add_to_group("show")
+
+	var childA := add_node(constructor.call(), parent, "ChildA")
+
+	nodes = [parent, childA]
+	for n in nodes:
+		n.hide()
+		assert_eq(n.scale, Vector2.ONE)
+
+	watch_rakugo_signals()
+	watch_custom_statments()
+	await wait_parse_and_execute_script(file_path)
+
+	await wait_step("start")
+
+	await wait_test_show([parent, childA])
+	await wait_step()
+
+	await wait_for_custom_statement(RKSShow.ScalePrecise, 0.2)
+	assert_eq(
+		parent.scale, Vector2(0.2, 0.4),
+		"\n-- 'scale 0.2 0.4' at %d --" % line_num
+	)
+	await wait_step()
+
+	await wait_for_custom_statement(RKSShow.ScaleAxis, 0.2)
+	assert_eq(
+		parent.scale, Vector2.ONE * 2,
+		"\n-- 'scale = 2' at %d --" % line_num
+	)
+	await wait_step()
+
+	var prev_scale = parent.scale
+	await wait_for_custom_statement(RKSShow.ScaleAxis, 0.2)
+	assert_eq(
+		parent.scale, prev_scale - 2 * Vector2.ONE,
+		"\n-- 'scale -= 2' at %d --" % line_num
+	)
+	await wait_step()
+
+	var prev_x = parent.scale.x
+	await wait_for_custom_statement(RKSShow.ScaleAxis, 0.2)
+	assert_almost_eq(
+		parent.scale.x, prev_x + 0.5, 0.01,
+		"\n-- 'scale x +0.5' at %d --" % line_num
+	)
+	await wait_step()
+
+	var prev_y = parent.scale.y
+	await wait_for_custom_statement(RKSShow.ScaleAxis, 0.2)
+	assert_almost_eq(
+		parent.scale.y, prev_y - 2.5, 0.01,
+		"\n-- 'scale y -2.5' at %d --" % line_num
+	)
+	await wait_step()
+
+	prev_x = parent.scale.x
+	await wait_for_custom_statement(RKSShow.ScaleAxis, 0.2)
+	assert_almost_eq(
+		parent.scale.x, prev_x / 2.0, 0.01,
+		"\n-- 'scale x /2' at %d --" % line_num
+	)
+	await wait_step()
+
+	prev_x = parent.scale.x
+	await wait_for_custom_statement(RKSShow.ScaleAxis, 0.2)
+	assert_almost_eq(
+		parent.scale.x, prev_x * 3.0, 0.01,
+		"\n-- 'scale x *3' at %d --" % line_num
+	)
+	await wait_step()
+
+	await wait_for_custom_statement(RKSShow.Hide, 0.2)
+	assert_false(parent.visible)
+	await wait_step("end")
+
+	await wait_execute_script_finished(file_base_name)
+
+	if !nodes.is_empty():
+		for n in nodes:
+			n.queue_free()
+

--- a/Test/TestVNKExtensions/TestScale2D.rk
+++ b/Test/TestVNKExtensions/TestScale2D.rk
@@ -3,9 +3,9 @@
 	"step"
 	scale 0.2 -0.4
 	"step"
-	scale = 2
+	scale xy = 2
 	"step"
-	scale -= 2
+	scale x = -2
 	"step"
 	scale x += 0.5
 	"step"

--- a/Test/TestVNKExtensions/TestScale2D.rk
+++ b/Test/TestVNKExtensions/TestScale2D.rk
@@ -1,0 +1,19 @@
+	"start"
+	show Parent ChildA
+	"step"
+	scale 0.2 -0.4
+	"step"
+	scale = 2
+	"step"
+	scale -= 2
+	"step"
+	scale x += 0.5
+	"step"
+	scale y -= 2.5
+	"step"
+	scale x /= 2
+	"step"
+	scale x *= 3
+	"step"
+	hide Parent
+	"end"

--- a/Test/TestVNKExtensions/TestScale3D.gd
+++ b/Test/TestVNKExtensions/TestScale3D.gd
@@ -1,0 +1,103 @@
+extends KitTest
+
+const file_path = "res://Test/TestVNKExtensions/TestScale3D.rk"
+var file_base_name = get_file_base_name(file_path)
+var nodes: Array[Node]
+
+var at_predefs := RKSShow.at_predefs
+
+func wait_test_show(xnodes: Array[Node]):
+	await wait_for_custom_statement("show", 0.2)
+	for node: Node in xnodes:
+		assert_true(node.visible)
+
+func test_node3d():
+	await make_test(Node3D.new)
+
+func make_test(constructor : Callable):
+	var parent := add_node(constructor.call(), null, "Parent")
+	parent.add_to_group("show")
+
+	var childA := add_node(constructor.call(), parent, "ChildA")
+
+	nodes = [parent, childA]
+	for n in nodes:
+		n.hide()
+		assert_eq(n.scale, Vector3.ONE)
+
+	watch_rakugo_signals()
+	watch_custom_statments()
+	await wait_parse_and_execute_script(file_path)
+
+	await wait_step("start")
+
+	await wait_test_show([parent, childA])
+	await wait_step()
+
+	await wait_for_custom_statement(RKSShow.ScalePrecise, 0.2)
+	assert_eq(
+		parent.scale, Vector3(0.2, -0.4, 0.6),
+		"\n-- 'scale 0.2 -0.4 0.6' at %d --" % line_num
+	)
+	await wait_step()
+
+	await wait_for_custom_statement(RKSShow.ScaleAxis, 0.2)
+	assert_eq(
+		parent.scale, Vector3.ONE * 2,
+		"\n-- 'scale xyz = 2' at %d --" % line_num
+	)
+	await wait_step()
+
+	await wait_for_custom_statement(RKSShow.ScaleAxis, 0.2)
+	assert_eq(
+		parent.scale.x, -2,
+		"\n-- 'scale xy = -2' at %d --" % line_num
+	)
+	assert_eq(
+		parent.scale.y, -2,
+		"\n-- 'scale xy = -2' at %d --" % line_num
+	)
+	await wait_step()
+
+	var prev_x = parent.scale.x
+	await wait_for_custom_statement(RKSShow.ScaleAxis, 0.2)
+	assert_almost_eq(
+		parent.scale.x, prev_x + 0.5, 0.01,
+		"\n-- 'scale x += 0.5' at %d --" % line_num
+	)
+	await wait_step()
+
+	var prev_y = parent.scale.y
+	await wait_for_custom_statement(RKSShow.ScaleAxis, 0.2)
+	assert_almost_eq(
+		parent.scale.y, prev_y - 2.5, 0.01,
+		"\n-- 'scale y -= 2.5' at %d --" % line_num
+	)
+	await wait_step()
+
+	prev_x = parent.scale.x
+	await wait_for_custom_statement(RKSShow.ScaleAxis, 0.2)
+	assert_almost_eq(
+		parent.scale.x, prev_x / 2.0, 0.01,
+		"\n-- 'scale x /= 2' at %d --" % line_num
+	)
+	await wait_step()
+
+	var prev_z = parent.scale.z
+	await wait_for_custom_statement(RKSShow.ScaleAxis, 0.2)
+	assert_almost_eq(
+		parent.scale.z, prev_z * 3.0, 0.1,
+		"\n-- 'scale z *= 3' at %d --" % line_num
+	)
+	await wait_step()
+
+	await wait_for_custom_statement(RKSShow.Hide, 0.2)
+	assert_false(parent.visible)
+	await wait_step("end")
+
+	await wait_execute_script_finished(file_base_name)
+
+	if !nodes.is_empty():
+		for n in nodes:
+			n.queue_free()
+

--- a/Test/TestVNKExtensions/TestScale3D.rk
+++ b/Test/TestVNKExtensions/TestScale3D.rk
@@ -1,0 +1,19 @@
+	"start"
+	show Parent ChildA
+	"step"
+	scale 0.2 -0.4 0.6
+	"step"
+	scale xyz = 2
+	"step"
+	scale xy = -2
+	"step"
+	scale x += 0.5
+	"step"
+	scale y -= 2.5
+	"step"
+	scale x /= 2
+	"step"
+	scale z *= 3
+	"step"
+	hide Parent
+	"end"

--- a/Test/TestVNKExtensions/TestShowHide.gd
+++ b/Test/TestVNKExtensions/TestShowHide.gd
@@ -5,7 +5,7 @@ var file_base_name = get_file_base_name(file_path)
 var nodes: Array[Node]
 
 func wait_test_show(xnodes: Array[Node]):
-	await wait_for_custom_statement("show", 0.2)
+	await wait_for_custom_statement(RKSShow.Show, 0.2)
 	for node: Node in xnodes:
 		assert_true(node.visible)
 
@@ -55,11 +55,11 @@ func make_test(constructor : Callable):
 	assert_false(childAB.visible)
 	await wait_step()
 	
-	await wait_for_custom_statement("hide", 0.2)
+	await wait_for_custom_statement(RKSShow.Hide, 0.2)
 	assert_false(childAC.visible)
 	await wait_step()
 	
-	await wait_for_custom_statement("hide", 0.2)
+	await wait_for_custom_statement(RKSShow.Hide, 0.2)
 	assert_false(parent.visible)
 	await wait_step("end")
 

--- a/addons/visualnovelkit/rks_extensions/rks_show.gd
+++ b/addons/visualnovelkit/rks_extensions/rks_show.gd
@@ -9,8 +9,10 @@ const Show := "show"
 const Hide := "hide"
 const AtPrecise = "at precise"
 const AtPercent = "at percent"
-const AtOne = "at one"
+const AtAxis = "at axis"
 const AtPredef = "at predef"
+const ScalePrecise = "scale precise"
+const ScaleAxis = "scale axis"
 
 const regex := {
 	Show:
@@ -21,10 +23,15 @@ const regex := {
 		"^at +({NUMERIC}) +({NUMERIC})( +({NUMERIC}))?$",
 	AtPercent:
 		"^at% +({NUMERIC}) +({NUMERIC})$",
-	AtOne:
-		"^at +([xyz]) *([-+\\*\\/])?=? *({NUMERIC})$",
+	AtAxis:
+		"^at +([xyz]{1,3}) *([-+\\*\\/])?=? *({NUMERIC})$",
 	AtPredef:
 		"^at +(\\w+)$",
+	ScalePrecise:
+		"^scale +({NUMERIC}) +({NUMERIC})( +({NUMERIC}))?$",
+	ScaleAxis:
+		"^scale +([xyz]{0,3}) *([-+\\*\\/])?= *({NUMERIC})$",
+
 }
 
 @onready
@@ -104,7 +111,7 @@ func _on_custom_regex(key:String, result:RegExMatch):
 			
 			last_node.position = Vector2(x, y)
 		
-		AtOne:
+		AtAxis:
 			if !last_node:
 				push_error(err_mess_04 % ["at", Show])
 				return
@@ -116,11 +123,15 @@ func _on_custom_regex(key:String, result:RegExMatch):
 			var axis := result.get_string(1)
 			var operator := result.get_string(2)
 			var value := float(result.get_string(3))
-			last_node.position = at_one(
+			last_node.position = calc_axis(
 				last_node.position, operator, axis, value
 			)
-			
+		
 		AtPercent:
+			if !last_node:
+				push_error(err_mess_04 % ["at", Show])
+				return
+
 			var procent := Vector2()
 			procent.x = float(result.get_string(1))/100
 			procent.y = float(result.get_string(2))/100
@@ -128,12 +139,87 @@ func _on_custom_regex(key:String, result:RegExMatch):
 			last_node.position = procent * vp_size
 		
 		AtPredef:
+			if !last_node:
+				push_error(err_mess_04 % ["at", Show])
+				return
+			
 			var predef := result.get_string(1)
 			var procent : Vector2 = at_predefs[predef]
 			var vp_size := get_viewport().get_visible_rect().size
 			last_node.position = procent * vp_size
+		
+		ScalePrecise:
+			if !last_node:
+				push_error(err_mess_04 % ["scale", Show])
+				return
+			
+			if result.get_group_count() == 0:
+				# add error for to small numer of args ?
+				push_error("error: " + result.get_string(0))
+				return
+			
+			var x := float(result.get_string(1))
+			var y := float(result.get_string(2))
+	
+			if result.get_string(4):
+				var z := float(result.get_string(4))
+				last_node.scale = Vector3(x, y, z)
+				return
+			
+			last_node.scale = Vector2(x, y)
+			return
+		
+		ScaleAxis:
+			if !last_node:
+				push_error(err_mess_04 % ["scale", Show])
+				return
+			
+			if result.get_group_count() == 0:
+				# add error for to small numer of args ?
+				return
+			
+			var axis := result.get_string(1)
+			var operator := result.get_string(2)
+			var value := float(result.get_string(3))
 
-func at_one_calc(axis:float, operator:String, value:float) -> float:
+			last_node.scale = calc_axis(
+				last_node.scale, operator, axis, value
+			)
+
+
+func calc_axis(vector, operator: String, axis:String, value:float):
+	match axis:
+		"x":
+			vector.x = _axis(vector.x, operator, value)
+			
+		"y":
+			vector.y = _axis(vector.y, operator, value)
+
+		"z":
+			vector.z = _axis(vector.z, operator, value)
+
+		"xy", "yx":
+			vector.x = _axis(vector.x, operator, value)
+			vector.y = _axis(vector.y, operator, value)
+
+		"xz", "zx":
+			vector.z = _axis(vector.z, operator, value)
+			vector.x = _axis(vector.x, operator, value)
+
+		"zy", "yz":
+			vector.y = _axis(vector.y, operator, value)
+			vector.z = _axis(vector.z, operator, value)
+
+		_:
+			vector.x = _axis(vector.x, operator, value)
+			vector.y = _axis(vector.y, operator, value)
+
+			if vector is Vector3:
+				vector.z = _axis(vector.z, operator, value)
+	
+	return vector
+
+func _axis(axis:float, operator:String, value:float) -> float:
 	match operator:
 		"-":
 			return axis - value
@@ -146,14 +232,4 @@ func at_one_calc(axis:float, operator:String, value:float) -> float:
 		_:
 			return value
 
-func at_one(vector, operator: String, axis:String, value:float):
-	match axis:
-		"x":
-			vector.x = at_one_calc(vector.x, operator, value)
-		"y":
-			vector.y = at_one_calc(vector.y, operator, value)
-		"z":
-			vector.z = at_one_calc(vector.z, operator, value)
-	
-	return vector
 

--- a/addons/visualnovelkit/rks_extensions/rks_show.gd
+++ b/addons/visualnovelkit/rks_extensions/rks_show.gd
@@ -30,7 +30,7 @@ const regex := {
 	ScalePrecise:
 		"^scale +({NUMERIC}) +({NUMERIC})( +({NUMERIC}))?$",
 	ScaleAxis:
-		"^scale +([xyz]{0,3}) *([-+\\*\\/])?= *({NUMERIC})$",
+		"^scale +([xyz]{1,3}) *([-+\\*\\/])?= *({NUMERIC})$",
 
 }
 


### PR DESCRIPTION
Implements #167 ,
for some strange error `scale = 2` doesn't do anthing, but it is parssed no problem.
So I make that you need to use `scale 2 2` or `scale xy = 2` in case **Vector2** 
and`scale 2 2 2` or `scale xyz = 2` in case **Vector3**.