### PR TITLE
Fix unsupported "at" syntax in test_dialogue

### DIFF
--- a/scenes/Game/test_dialogue.rk
+++ b/scenes/Game/test_dialogue.rk
@@ -42,9 +42,9 @@ test_at:
 	"Click next and godot move to 148 156"
 	at 148 156
 	"Click next and godot move to 200 on y axis"
-	at y 200
+	at y = 200
 	"Click next and godot move by 50 on x axis"
-	at x +50
+	at x += 50
 	"Click next and godot move to 25% 25% procent of window"
 	at% 25 25
 	"Click next and godot logo should hide"


### PR DESCRIPTION
In https://github.com/rakugoteam/VisualNovelKit/commit/7c637ed6c1920b8e6b0a88546981608b67509b0e#diff-085abdb4fc4b8dac6a8232d618380f81d0f7b0f471d57d790aa85eaaf020afe9R30, the `at`-statement was updated to always need an `=`-sign.

`test_dialogue.rk` was not updated accordingly, tripping the parser and making the kit unusable with the default (test-) dialogue.